### PR TITLE
Update CI workflows for client and serverless

### DIFF
--- a/.github/workflows/client.ci.yml
+++ b/.github/workflows/client.ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           cd common
           npm ci
-          npx tsc
+          npm run build
       - name: 'Client: Install deps and build'
         run: |
           npm ci

--- a/.github/workflows/serverless.ci.yml
+++ b/.github/workflows/serverless.ci.yml
@@ -18,17 +18,15 @@ jobs:
         with:
           node-version: '18.x'
           cache: 'npm'
-      - name: 'Common module: Install deps and compile'
+      - name: 'Common module: build script'
         run: |
-          cd common
-          npm ci
-      - name: 'get-leaderboard-entries: Install deps and build'
+          cd serverless/lib
+          ./build.sh
+      - name: 'get-leaderboard-entries: build script'
         run: |
           cd serverless/packages/starsweeper/get-leaderboard-entries
-          npm install
-          npm run build
-      - name: 'save-new-top-time: Install deps and build'
+          ./build.sh
+      - name: 'save-new-top-time: build script'
         run: |
           cd serverless/packages/starsweeper/save-new-top-time
-          npm install
-          npm run build
+          ./build.sh


### PR DESCRIPTION
Workflows now execute build scripts, instead of the workflow doing the building itself. Components for serverless functions are built using build.sh, which DigitalOcean also uses in their build process when deploying.